### PR TITLE
docs: require PR template usage in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ When asked about various services or tools, use these resources to help you:
 
 ## Pull Request Requirements
 
+- **ALL pull requests MUST use the template in `.github/pull_request_template.md`**
 - Include a clear description of changes
 - Reference any related issues
 - Pass CI (`npm test`)


### PR DESCRIPTION
## Summary
- Add explicit requirement that PRs MUST use the template in `.github/pull_request_template.md`
- Makes the requirement visible and prominent in AGENTS.md guidelines

## Details
The Pull Request Requirements section now clearly states that all PRs must use the provided template, ensuring consistency across contributions.

## Test plan
- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [x] Manual testing