### PR TITLE
docs: add TypeScript SDK reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tigris Storage SDK for Go
 
+> **Looking for TypeScript?** The Tigris Storage TypeScript SDK is available at [github.com/tigrisdata/storage](https://github.com/tigrisdata/storage) or on NPM as [`@tigrisdata/storage`](https://www.npmjs.com/package/@tigrisdata/storage).
+
 Welcome to the Tigris Storage SDK for Go! This package contains high-level wrappers and helpers to help you take advantage of all of Tigris' features.
 
 ## Overview


### PR DESCRIPTION
## Summary
- Add TypeScript SDK reference link at the top of the Go SDK README
- Links to both GitHub repo and NPM package for easy discovery

## Details
Users searching for Tigris Storage SDK documentation may land in the wrong language repository. Adding a prominent link to the TypeScript SDK at the top helps TypeScript/JavaScript developers quickly find the correct package.

## Test plan
- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format` (pre-commit hook ran)
- [x] Manual testing - viewed README locally to verify formatting

Assisted-by: GLM 4.7 via Claude Code