### PR TITLE
chore: add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Tigris Data
+Copyright (c) 2025-2026 Tigris Data
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Add MIT License to the repository

## Details
Adds the standard MIT License file, consistent with other Tigris Data projects like [mcp-oidc-provider](https://github.com/tigrisdata/mcp-oidc-provider).

## Test plan
- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [ ] Manual testing