### PR TITLE
chore: add Go table-driven test skill

### DIFF
--- a/.claude/skills/table-driven-test/SKILL.md
+++ b/.claude/skills/table-driven-test/SKILL.md
@@ -315,7 +315,7 @@ for name, tt := range tests {
 
 ### Parallel Testing
 
-To run test cases in parallel, add `t.Parallel()` calls. For Go 1.22+, the loop variable is automatically captured per iteration:
+To run test cases in parallel, add `t.Parallel()` calls. The loop variable is automatically captured per iteration:
 
 ```go
 func TestFunction(t *testing.T) {
@@ -332,18 +332,6 @@ func TestFunction(t *testing.T) {
             // test implementation
         })
     }
-}
-```
-
-**Note:** For Go versions prior to 1.22, you must re-declare the loop variable to avoid closure issues:
-
-```go
-for _, tt := range tests {
-    tt := tt // capture loop variable
-    t.Run(tt.name, func(t *testing.T) {
-        t.Parallel()
-        // ...
-    })
 }
 ```
 


### PR DESCRIPTION
## Summary

Add a Claude Code skill for writing Go table-driven tests following established patterns in this codebase.

## Details

The skill at `.claude/skills/table-driven-test/SKILL.md` documents:

- **Table Structure Pattern** - Standard struct with `name`, `input`, `want`, `wantErr`, `errCheck`, `setupEnv` fields
- **Common Patterns** - Basic tests, error checking, custom error validation, environment setup
- **Integration Test Guards** - `skipIfNoCreds(t)` pattern for tests requiring real Tigris credentials
- **Test Helpers** - Using `t.Helper()` for proper line reporting
- **Additional Best Practices** - From Go Wiki and Dave Cheney's blog:
  - Detailed error messages (`got %q, want %q`)
  - Using maps for test cases (non-deterministic iteration ensures independence)
  - Parallel testing with `t.Parallel()`

## Test plan
- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [x] Manual testing - skill follows patterns from existing test files in the repo