### PR TITLE
fix: require Signed-off-by in commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       ],
       "signed-off-by": [
         2,
-        "always"
+        "always",
+        "Signed-off-by:"
       ]
     }
   },


### PR DESCRIPTION
## Summary

- Fix commitlint DCO signoff enforcement
- Add missing pattern parameter to `signed-off-by` rule

## Details

The `signed-off-by` commitlint rule was configured but not actually enforcing the DCO requirement. The rule was defined as `[2, "always"]` without a pattern value, causing it to check `last.startsWith("")` which always returns `true`.

This change adds `"Signed-off-by:"` as the third parameter, so the rule now correctly validates that all commits include a proper DCO signoff trailer (added via `git commit --signoff`).

## Test plan

- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [x] Manual testing
  - Verified commitlint rejects commits without `Signed-off-by:`
  - Verified commitlint passes commits with proper signoff