### PR TITLE
docs: remove TypeScript SDK shoutout from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Tigris Storage SDK for Go
 
-> **Looking for TypeScript?** The Tigris Storage TypeScript SDK is available at [github.com/tigrisdata/storage](https://github.com/tigrisdata/storage) or on NPM as [`@tigrisdata/storage`](https://www.npmjs.com/package/@tigrisdata/storage).
-
 Welcome to the Tigris Storage SDK for Go! This package contains high-level wrappers and helpers to help you take advantage of all of Tigris' features.
 
 ## Overview


### PR DESCRIPTION
## Summary

- Removes the TypeScript SDK callout from the top of the Go SDK README

## Details

The README previously had a shoutout box pointing users to the TypeScript SDK. This is no longer needed.

## Test plan

- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [x] Manual testing