### PR TITLE
feat(storage): suppress AWS SDK logging with Nop logger

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -12,6 +12,7 @@ import (
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go/logging"
 )
 
 const (
@@ -125,7 +126,9 @@ func New(ctx context.Context, options ...Option) (*Client, error) {
 		creds = credentials.NewStaticCredentialsProvider(o.AccessKeyID, o.SecretAccessKey, "")
 	}
 
-	cfg, err := awsConfig.LoadDefaultConfig(ctx)
+	cfg, err := awsConfig.LoadDefaultConfig(ctx,
+		awsConfig.WithLogger(logging.Nop{}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load Tigris config: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Add `config.WithLogger(logging.Nop{})` to suppress AWS SDK default logging
- Prevents unwanted log output from AWS SDK when using the storage client

## Details

The AWS SDK v2 logs debug information by default. This change adds a no-op logger to suppress that output, keeping application logs clean while not affecting functionality.

## Test plan

- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [x] All tests pass with `go test ./...`