### PR TITLE
ci(release): add automatic cleanup of stale release branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,3 +65,14 @@ jobs:
             --base main \
             --head "${BRANCH_NAME}" \
             --label "release"
+
+      - name: Clean up old release branches
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get all release branches except the current one
+          for branch in $(git ls-remote --heads origin "release-*" | awk '{print $2}' | sed 's|refs/heads/||' | grep -v "^${BRANCH_NAME}$"); do
+            echo "Deleting old release branch: ${branch}"
+            git push origin --delete "${branch}" || true
+          done


### PR DESCRIPTION
## Summary

- Adds cleanup step to release workflow to delete old `release-*` branches
- Prevents accumulation of stale branches that break semantic-release

## Details

The semantic-release configuration allows only 1-3 release branches, but stale `release-*` branches from previous release PRs were accumulating. This caused semantic-release to fail with "ERELEASEBRANCHES" errors.

The fix adds a cleanup step that runs at the end of the release workflow (even if earlier steps fail) and deletes all old `release-*` branches except the one just created.

## Test plan

- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [ ] Manual testing