### PR TITLE
feat(simplestorage)!: support iterators

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,11 +3,11 @@ package storage
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/tigrisdata/storage-go/tigrisheaders"
 )
 
@@ -54,7 +54,7 @@ func (c *Client) CreateBucketSnapshot(ctx context.Context, description string, i
 	}
 
 	out := &CreateBucketSnapshotOutput{CreateBucketOutput: resp}
-	if rawResp, ok := middleware.GetRawResponse(resp.ResultMetadata).(*http.Response); ok {
+	if rawResp, ok := middleware.GetRawResponse(resp.ResultMetadata).(*smithyhttp.Response); ok {
 		out.SnapshotVersion = rawResp.Header.Get("X-Tigris-Snapshot-Version")
 	}
 	return out, nil
@@ -86,7 +86,7 @@ func (c *Client) HeadBucketForkOrSnapshot(ctx context.Context, in *s3.HeadBucket
 		return nil, err
 	}
 
-	rawResp, ok := middleware.GetRawResponse(resp.ResultMetadata).(*http.Response)
+	rawResp, ok := middleware.GetRawResponse(resp.ResultMetadata).(*smithyhttp.Response)
 	if !ok {
 		return nil, fmt.Errorf("unexpected response type from middleware")
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigrisdata/storage-go
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/simplestorage/bucket_options.go
+++ b/simplestorage/bucket_options.go
@@ -43,6 +43,10 @@ type BucketOptions struct {
 
 	// S3Options are additional S3 options passed through to the underlying client.
 	S3Options []func(*s3.Options)
+
+	// GrabForkInfo makes Buckets calls grab additional information about buckets from
+	// Tigris about forkability and what snapshot the bucket was forked from.
+	GrabForkInfo bool
 }
 
 // defaults populates BucketOptions with default values.
@@ -131,6 +135,16 @@ func WithForkSourceSnapshot(snapshot string) BucketOption {
 func WithBucketAccess(access AccessType) BucketOption {
 	return func(o *BucketOptions) {
 		o.Access = access
+	}
+}
+
+// WithGrabForkInfo instructs the Buckets() call to grab additional information about
+// bucket forkability and the snapshot each bucket was based on.
+//
+// Using this will incur an additional Tigris round trip per invocation.
+func WithGrabForkInfo() BucketOption {
+	return func(o *BucketOptions) {
+		o.GrabForkInfo = true
 	}
 }
 

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -266,11 +266,6 @@ func (c *Client) Snapshot(ctx context.Context, bucket, description string, opts 
 }
 
 // Snapshots lists all snapshots for the given bucket.
-//
-// Tigris returns each snapshot as a pseudo-bucket entry whose Name is the
-// snapshot version identifier. The user-provided description is not returned
-// by the ListBuckets API, so SnapshotInfo.Name is left empty; use the version
-// from CreateBucketSnapshot's response if you need to correlate descriptions.
 func (c *Client) Snapshots(ctx context.Context, bucket string, opts ...BucketOption) iter.Seq2[*SnapshotInfo, error] {
 	o := new(BucketOptions).defaults()
 	for _, doer := range opts {

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -269,27 +269,39 @@ func (c *Client) Snapshots(ctx context.Context, bucket string, opts ...BucketOpt
 	o.S3Options = append(o.S3Options, tigrisheaders.WithHeader("X-Tigris-Snapshot", bucket))
 
 	return func(yield func(snapshotInfo *SnapshotInfo, err error) bool) {
-		resp, err := c.cli.ListBuckets(ctx, &s3.ListBucketsInput{}, o.S3Options...)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
+		continueToken := o.ContinuationToken
 
-		for _, snapshot := range resp.Buckets {
-			// Tigris encodes each snapshot as a pseudo-bucket whose Name is the
-			// snapshot version followed by the description, e.g.
-			// "1779907846120844367; name=my+snapshot". Split the two apart and
-			// decode the description (spaces are encoded as "+").
-			version, desc, _ := strings.Cut(lower(snapshot.Name, ""), "; name=")
-
-			if !yield(&SnapshotInfo{
-				Name:    strings.ReplaceAll(desc, "+", " "),
-				Version: version,
-				Created: lower(snapshot.CreationDate, time.Time{}),
-				Bucket:  bucket,
-			}, nil) {
+		for {
+			resp, err := c.cli.ListBuckets(ctx, &s3.ListBucketsInput{
+				ContinuationToken: continueToken,
+			}, o.S3Options...)
+			if err != nil {
+				yield(nil, err)
 				return
 			}
+
+			for _, snapshot := range resp.Buckets {
+				// Tigris encodes each snapshot as a pseudo-bucket whose Name is the
+				// snapshot version followed by the description, e.g.
+				// "1779907846120844367; name=my+snapshot". Split the two apart and
+				// decode the description (spaces are encoded as "+").
+				version, desc, _ := strings.Cut(lower(snapshot.Name, ""), "; name=")
+
+				if !yield(&SnapshotInfo{
+					Name:    strings.ReplaceAll(desc, "+", " "),
+					Version: version,
+					Created: lower(snapshot.CreationDate, time.Time{}),
+					Bucket:  bucket,
+				}, nil) {
+					return
+				}
+			}
+
+			// An empty or absent continuation token means there are no more pages.
+			if resp.ContinuationToken == nil || *resp.ContinuationToken == "" {
+				return
+			}
+			continueToken = resp.ContinuationToken
 		}
 	}
 }

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -225,10 +225,10 @@ func (c *Client) GetBucketInfo(ctx context.Context, bucket string, opts ...Bucke
 	}, nil
 }
 
-// CreateBucketSnapshot creates a snapshot with the given description for a bucket.
+// Snapshot creates a snapshot with the given description for a bucket.
 //
 // The bucket must have snapshots enabled (created with WithEnableSnapshot()).
-func (c *Client) CreateBucketSnapshot(ctx context.Context, bucket, description string, opts ...BucketOption) (*SnapshotInfo, error) {
+func (c *Client) Snapshot(ctx context.Context, bucket, description string, opts ...BucketOption) (*SnapshotInfo, error) {
 	if bucket == "" {
 		return nil, ErrBucketNameRequired
 	}

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -141,8 +141,9 @@ func containsBucketNotEmptyError(err error) bool {
 
 // Buckets lists all buckets that the authenticated user has access to.
 //
-// This returns an iterator over all of your buckets including Tigris-specific
-// metadata about forks and snapshots.
+// This returns an iterator over all of your buckets. If you want this to include
+// Tigris-specific information such as forkability and what snapshot this bucket was
+// based upon, use the WithGrabForkInfo() functional option.
 func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*BucketInfo, error] {
 	o := new(BucketOptions).defaults()
 	for _, doer := range opts {
@@ -166,16 +167,26 @@ func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*B
 			}
 
 			for _, bucket := range resp.Buckets {
-				bi, err := c.GetBucketInfo(ctx, *bucket.Name)
-				if err != nil {
-					if !yield(nil, err) {
+				switch o.GrabForkInfo {
+				case true:
+					bi, err := c.Info(ctx, *bucket.Name)
+					if err != nil {
+						if !yield(nil, err) {
+							return
+						}
+						continue
+					}
+
+					if !yield(bi, nil) {
 						return
 					}
-					continue
-				}
-
-				if !yield(bi, nil) {
-					return
+				case false:
+					if !yield(&BucketInfo{
+						Name:    lower(bucket.Name, ""),
+						Created: lower(bucket.CreationDate, time.Time{}),
+					}, nil) {
+						return
+					}
 				}
 			}
 

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -137,7 +137,11 @@ func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*B
 		doer(&o)
 	}
 
-	const maxBuckets int32 = 50
+	maxBuckets := o.MaxKeys
+	if maxBuckets == nil {
+		const defaultMaxBuckets int32 = 50
+		maxBuckets = new(defaultMaxBuckets)
+	}
 
 	return func(yield func(bucketInfo *BucketInfo, err error) bool) {
 		continueToken := o.ContinuationToken
@@ -145,7 +149,7 @@ func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*B
 		for {
 			resp, err := c.cli.ListBuckets(ctx, &s3.ListBucketsInput{
 				ContinuationToken: continueToken,
-				MaxBuckets:        new(maxBuckets),
+				MaxBuckets:        maxBuckets,
 			}, o.S3Options...)
 
 			if err != nil {

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -150,9 +150,10 @@ func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*B
 	}
 
 	const maxBuckets int32 = 50
-	continueToken := o.ContinuationToken
 
 	return func(yield func(bucketInfo *BucketInfo, err error) bool) {
+		continueToken := o.ContinuationToken
+
 		for {
 			resp, err := c.cli.ListBuckets(ctx, &s3.ListBucketsInput{
 				ContinuationToken: continueToken,

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -169,7 +169,7 @@ func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*B
 			for _, bucket := range resp.Buckets {
 				switch o.GrabForkInfo {
 				case true:
-					bi, err := c.Info(ctx, *bucket.Name)
+					bi, err := c.Info(ctx, lower(bucket.Name, ""))
 					if err != nil {
 						if !yield(nil, err) {
 							return

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"strings"
 	"time"
 
@@ -138,39 +139,52 @@ func containsBucketNotEmptyError(err error) bool {
 		strings.Contains(errMsg, "NotEmpty")
 }
 
-// ListBuckets lists all buckets that the authenticated user has access to.
+// Buckets lists all buckets that the authenticated user has access to.
 //
-// Use WithListToken() for pagination. Note that WithListLimit() is not supported
-// by the underlying S3 ListBuckets API and is ignored.
-func (c *Client) ListBuckets(ctx context.Context, opts ...BucketOption) (*BucketList, error) {
+// This returns an iterator over all of your buckets including Tigris-specific
+// metadata about forks and snapshots.
+func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*BucketInfo, error] {
 	o := new(BucketOptions).defaults()
 	for _, doer := range opts {
 		doer(&o)
 	}
 
-	resp, err := c.cli.ListBuckets(ctx, &s3.ListBucketsInput{
-		ContinuationToken: o.ContinuationToken,
-	}, o.S3Options...)
+	const maxBuckets int32 = 50
+	continueToken := o.ContinuationToken
 
-	if err != nil {
-		return nil, fmt.Errorf("simplestorage: can't list buckets: %w", err)
+	return func(yield func(bucketInfo *BucketInfo, err error) bool) {
+		for {
+			resp, err := c.cli.ListBuckets(ctx, &s3.ListBucketsInput{
+				ContinuationToken: continueToken,
+				MaxBuckets:        new(maxBuckets),
+			}, o.S3Options...)
+
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			for _, bucket := range resp.Buckets {
+				bi, err := c.GetBucketInfo(ctx, *bucket.Name)
+				if err != nil {
+					if !yield(nil, err) {
+						return
+					}
+					continue
+				}
+
+				if !yield(bi, nil) {
+					return
+				}
+			}
+
+			// An empty or absent continuation token means there are no more pages.
+			if resp.ContinuationToken == nil || *resp.ContinuationToken == "" {
+				return
+			}
+			continueToken = resp.ContinuationToken
+		}
 	}
-
-	result := &BucketList{
-		Buckets:   make([]BucketInfo, 0, len(resp.Buckets)),
-		Truncated: resp.ContinuationToken != nil,
-	}
-
-	for _, b := range resp.Buckets {
-		result.Buckets = append(result.Buckets, BucketInfo{
-			Name:    lower(b.Name, ""),
-			Created: lower(b.CreationDate, time.Time{}),
-		})
-	}
-
-	result.NextToken = lower(resp.ContinuationToken, "")
-
-	return result, nil
 }
 
 // GetBucketInfo retrieves metadata about the bucket with the given name.
@@ -239,41 +253,44 @@ func (c *Client) CreateBucketSnapshot(ctx context.Context, bucket, description s
 	}, nil
 }
 
-// ListBucketSnapshots lists all snapshots for the given bucket.
+// Snapshots lists all snapshots for the given bucket.
 //
 // Tigris returns each snapshot as a pseudo-bucket entry whose Name is the
 // snapshot version identifier. The user-provided description is not returned
 // by the ListBuckets API, so SnapshotInfo.Name is left empty; use the version
 // from CreateBucketSnapshot's response if you need to correlate descriptions.
-func (c *Client) ListBucketSnapshots(ctx context.Context, bucket string, opts ...BucketOption) (*SnapshotList, error) {
-	if bucket == "" {
-		return nil, ErrBucketNameRequired
-	}
-
+func (c *Client) Snapshots(ctx context.Context, bucket string, opts ...BucketOption) iter.Seq2[*SnapshotInfo, error] {
 	o := new(BucketOptions).defaults()
 	for _, doer := range opts {
 		doer(&o)
 	}
 
-	resp, err := c.cli.ListBucketSnapshots(ctx, bucket, o.S3Options...)
-	if err != nil {
-		return nil, fmt.Errorf("simplestorage: can't list snapshots for bucket %s: %w", bucket, err)
-	}
+	o.S3Options = append(o.S3Options, tigrisheaders.WithHeader("X-Tigris-Snapshot", bucket))
 
-	result := &SnapshotList{
-		Bucket:    bucket,
-		Snapshots: make([]SnapshotInfo, 0, len(resp.Buckets)),
-	}
+	return func(yield func(snapshotInfo *SnapshotInfo, err error) bool) {
+		resp, err := c.cli.ListBuckets(ctx, &s3.ListBucketsInput{}, o.S3Options...)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
 
-	for _, b := range resp.Buckets {
-		result.Snapshots = append(result.Snapshots, SnapshotInfo{
-			Version: lower(b.Name, ""),
-			Created: lower(b.CreationDate, time.Time{}),
-			Bucket:  bucket,
-		})
-	}
+		for _, snapshot := range resp.Buckets {
+			// Tigris encodes each snapshot as a pseudo-bucket whose Name is the
+			// snapshot version followed by the description, e.g.
+			// "1779907846120844367; name=my+snapshot". Split the two apart and
+			// decode the description (spaces are encoded as "+").
+			version, desc, _ := strings.Cut(lower(snapshot.Name, ""), "; name=")
 
-	return result, nil
+			if !yield(&SnapshotInfo{
+				Name:    strings.ReplaceAll(desc, "+", " "),
+				Version: version,
+				Created: lower(snapshot.CreationDate, time.Time{}),
+				Bucket:  bucket,
+			}, nil) {
+				return
+			}
+		}
+	}
 }
 
 // ForkBucket creates a fork of the source bucket with the given target name.

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -171,7 +171,10 @@ func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*B
 				case true:
 					bi, err := c.Info(ctx, lower(bucket.Name, ""))
 					if err != nil {
-						if !yield(nil, err) {
+						if !yield(&BucketInfo{
+							Name:    lower(bucket.Name, ""),
+							Created: lower(bucket.CreationDate, time.Time{}),
+						}, nil) {
 							return
 						}
 						continue

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -188,11 +188,11 @@ func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*B
 	}
 }
 
-// GetBucketInfo retrieves metadata about the bucket with the given name.
+// Info retrieves metadata about the bucket with the given name.
 //
 // This includes Tigris-specific information like whether snapshots are enabled
 // and whether the bucket is a fork of another bucket.
-func (c *Client) GetBucketInfo(ctx context.Context, bucket string, opts ...BucketOption) (*BucketInfo, error) {
+func (c *Client) Info(ctx context.Context, bucket string, opts ...BucketOption) (*BucketInfo, error) {
 	if bucket == "" {
 		return nil, ErrBucketNameRequired
 	}

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -39,25 +39,12 @@ type BucketInfo struct {
 	SourceSnapshot   string // If this is a fork, the snapshot version
 }
 
-// BucketList contains a paginated list of buckets.
-type BucketList struct {
-	Buckets   []BucketInfo // List of buckets
-	NextToken string       // Pagination token for next page
-	Truncated bool         // True if more results available
-}
-
 // SnapshotInfo contains metadata about a bucket snapshot.
 type SnapshotInfo struct {
 	Name    string    // Snapshot name/description
 	Version string    // Snapshot version ID
 	Created time.Time // Creation time
 	Bucket  string    // Source bucket name
-}
-
-// SnapshotList contains a list of snapshots for a bucket.
-type SnapshotList struct {
-	Snapshots []SnapshotInfo // List of snapshots
-	Bucket    string         // Source bucket name
 }
 
 // CreateBucket creates a new bucket with the given name.

--- a/simplestorage/buckets.go
+++ b/simplestorage/buckets.go
@@ -167,6 +167,7 @@ func (c *Client) Buckets(ctx context.Context, opts ...BucketOption) iter.Seq2[*B
 						continue
 					}
 
+					bi.Created = lower(bucket.CreationDate, time.Time{})
 					if !yield(bi, nil) {
 						return
 					}

--- a/simplestorage/buckets_example_test.go
+++ b/simplestorage/buckets_example_test.go
@@ -67,7 +67,7 @@ func ExampleClient_DeleteBucket() {
 	}
 }
 
-func ExampleClient_ListBuckets() {
+func ExampleClient_Buckets() {
 	ctx := context.Background()
 
 	client, err := simplestorage.New(ctx,
@@ -77,31 +77,13 @@ func ExampleClient_ListBuckets() {
 		log.Fatal(err)
 	}
 
-	// List all buckets
-	list, err := client.ListBuckets(ctx)
-	if err != nil {
-		log.Fatal(err) // handle the error here
-	}
-
-	for _, bucket := range list.Buckets {
-		fmt.Printf("Bucket: %s (created: %s)\n", bucket.Name, bucket.Created)
-	}
-
-	// Paginated listing
-	for {
-		list, err = client.ListBuckets(ctx,
-			simplestorage.WithListLimit(50),
-			simplestorage.WithListToken(list.NextToken),
-		)
+	// ListBuckets returns an iterator that transparently handles pagination.
+	for bucket, err := range client.Buckets(ctx) {
 		if err != nil {
 			log.Fatal(err) // handle the error here
 		}
 
-		// Process buckets...
-
-		if !list.Truncated {
-			break
-		}
+		fmt.Printf("Bucket: %s (created: %s)\n", bucket.Name, bucket.Created)
 	}
 }
 
@@ -146,24 +128,21 @@ func ExampleClient_CreateBucketSnapshot() {
 	fmt.Printf("Created snapshot: %s (version: %s)\n", snapshot.Name, snapshot.Version)
 }
 
-func ExampleClient_ListBucketSnapshots() {
+func ExampleClient_Snapshots() {
 	ctx := context.Background()
 
 	client, err := simplestorage.New(ctx,
 		simplestorage.WithBucket("my-default-bucket"),
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) // handle error here
 	}
 
-	// List all snapshots for a bucket
-	snapshots, err := client.ListBucketSnapshots(ctx, "my-bucket")
-	if err != nil {
-		log.Fatal(err) // handle the error here
-	}
-
-	for _, snap := range snapshots.Snapshots {
-		fmt.Printf("Snapshot: %s (version: %s, created: %s)\n", snap.Name, snap.Version, snap.Created)
+	for snapshot, err := range client.Snapshots(ctx, "my-bucket") {
+		if err != nil {
+			log.Fatal(err) // handle error here
+		}
+		fmt.Printf("Snapshot: %s (version: %s, created: %s)\n", snapshot.Name, snapshot.Version, snapshot.Created)
 	}
 }
 

--- a/simplestorage/buckets_example_test.go
+++ b/simplestorage/buckets_example_test.go
@@ -87,7 +87,7 @@ func ExampleClient_Buckets() {
 	}
 }
 
-func ExampleClient_GetBucketInfo() {
+func ExampleClient_Info() {
 	ctx := context.Background()
 
 	client, err := simplestorage.New(ctx,
@@ -98,7 +98,7 @@ func ExampleClient_GetBucketInfo() {
 	}
 
 	// Get bucket information
-	info, err := client.GetBucketInfo(ctx, "my-bucket")
+	info, err := client.Info(ctx, "my-bucket")
 	if err != nil {
 		log.Fatal(err) // handle the error here
 	}
@@ -209,7 +209,7 @@ func Example_bucketManagementWorkflow() {
 	_ = forkInfo // Use the fork info
 
 	// Get bucket info
-	info, err = client.GetBucketInfo(ctx, "my-forked-bucket")
+	info, err = client.Info(ctx, "my-forked-bucket")
 	if err != nil {
 		log.Fatal(err) // handle the error here
 	}

--- a/simplestorage/buckets_example_test.go
+++ b/simplestorage/buckets_example_test.go
@@ -109,7 +109,7 @@ func ExampleClient_GetBucketInfo() {
 	fmt.Printf("Source snapshot: %s\n", info.SourceSnapshot)
 }
 
-func ExampleClient_CreateBucketSnapshot() {
+func ExampleClient_Snapshot() {
 	ctx := context.Background()
 
 	client, err := simplestorage.New(ctx,
@@ -120,7 +120,7 @@ func ExampleClient_CreateBucketSnapshot() {
 	}
 
 	// Create a named snapshot
-	snapshot, err := client.CreateBucketSnapshot(ctx, "my-bucket", "Backup before migration")
+	snapshot, err := client.Snapshot(ctx, "my-bucket", "Backup before migration")
 	if err != nil {
 		log.Fatal(err) // handle the error here
 	}
@@ -194,7 +194,7 @@ func Example_bucketManagementWorkflow() {
 	}
 
 	// Create a snapshot
-	snapshot, err := client.CreateBucketSnapshot(ctx, "my-new-bucket", "Initial state")
+	snapshot, err := client.Snapshot(ctx, "my-new-bucket", "Initial state")
 	if err != nil {
 		log.Fatal(err) // handle the error here
 	}

--- a/simplestorage/buckets_test.go
+++ b/simplestorage/buckets_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	_ "github.com/joho/godotenv/autoload"
+	"github.com/tigrisdata/storage-go/tigrisheaders"
 )
 
 // skipIfNoCreds skips the test if Tigris credentials are not set.
@@ -35,7 +36,9 @@ func setupTestBucket(t *testing.T, ctx context.Context, client *Client) string {
 	}
 
 	t.Cleanup(func() {
-		err := client.DeleteBucket(context.Background(), bucket)
+		err := client.DeleteBucket(context.Background(), bucket, func(bo *BucketOptions) {
+			bo.S3Options = append(bo.S3Options, tigrisheaders.WithHeader("Tigris-Force-Delete", "true"))
+		})
 		if err != nil {
 			t.Logf("cleanupTestBucket: failed to delete bucket %s: %v", bucket, err)
 		}
@@ -478,13 +481,18 @@ func TestBucketSnapshotList(t *testing.T) {
 
 func collect[T any](i iter.Seq2[T, error]) ([]T, error) {
 	var result []T
+	var errs []error
 
 	for item, err := range i {
 		if err != nil {
-			return nil, err
+			errs = append(errs, err)
 		}
 
 		result = append(result, item)
+	}
+
+	if len(errs) != 0 {
+		return nil, errors.Join(errs...)
 	}
 
 	return result, nil

--- a/simplestorage/buckets_test.go
+++ b/simplestorage/buckets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"os"
 	"testing"
 	"time"
@@ -182,9 +183,15 @@ func TestListBuckets(t *testing.T) {
 				t.Fatalf("New() failed: %v", err)
 			}
 
-			_, err = client.ListBuckets(context.Background())
+			var iterErr error
+			for _, err := range client.Buckets(context.Background()) {
+				if err != nil {
+					iterErr = err
+					break
+				}
+			}
 
-			if tt.wantErr && err == nil {
+			if tt.wantErr && iterErr == nil {
 				t.Errorf("ListBuckets() expected error, got nil")
 			}
 		})
@@ -361,41 +368,6 @@ func TestCreateBucketSnapshot(t *testing.T) {
 	}
 }
 
-func TestListBucketSnapshots(t *testing.T) {
-	tests := []struct {
-		name    string
-		bucket  string
-		wantErr bool
-	}{
-		{
-			name:    "empty bucket name returns error",
-			bucket:  "",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a client
-			os.Setenv("TIGRIS_STORAGE_BUCKET", "dummy-bucket")
-			defer os.Unsetenv("TIGRIS_STORAGE_BUCKET")
-
-			client, err := New(context.Background(),
-				WithEndpoint("https://test.endpoint.dev"),
-			)
-			if err != nil {
-				t.Fatalf("New() failed: %v", err)
-			}
-
-			_, err = client.ListBucketSnapshots(context.Background(), tt.bucket)
-
-			if tt.wantErr && err == nil {
-				t.Errorf("ListBucketSnapshots() expected error, got nil")
-			}
-		})
-	}
-}
-
 func TestForkBucket(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -464,4 +436,56 @@ func TestBucketLifecycle_integration(t *testing.T) {
 	if info.Name != bucket {
 		t.Errorf("GetBucketInfo() returned bucket name %s, want %s", info.Name, bucket)
 	}
+}
+
+func TestBucketSnapshotList(t *testing.T) {
+	skipIfNoCreds(t)
+	ctx := t.Context()
+
+	client, err := New(ctx, WithBucket("xxx-foo-test"))
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	bucket := setupTestBucket(t, ctx, client)
+	client = client.For(bucket)
+
+	snapshotName := t.Name()
+	sn, err := client.CreateBucketSnapshot(ctx, bucket, snapshotName)
+	if err != nil {
+		t.Fatalf("CreateBucketSnapshot(%q, %q) failed: %v", bucket, snapshotName, err)
+	}
+
+	snaps, err := collect(client.Snapshots(ctx, bucket))
+	if err != nil {
+		t.Fatalf("ListBucketSnapshots(%q) failed: %v", bucket, err)
+	}
+
+	if len(snaps) != 1 {
+		t.Errorf("wanted len(snaps) == 1 but got: %d", len(snaps))
+	}
+
+	gotSN := snaps[0]
+
+	if gotSN.Version != sn.Version {
+		t.Errorf("wanted snapshot version %s but got: %s", sn.Version, gotSN.Version)
+	}
+
+	if gotSN.Name != sn.Name {
+		t.Errorf("wanted snapshot name %q but got: %q", sn.Name, gotSN.Name)
+	}
+}
+
+func collect[T any](i iter.Seq2[T, error]) ([]T, error) {
+	var result []T
+
+	for item, err := range i {
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, item)
+	}
+
+	return result, nil
 }

--- a/simplestorage/buckets_test.go
+++ b/simplestorage/buckets_test.go
@@ -362,7 +362,7 @@ func TestCreateBucketSnapshot(t *testing.T) {
 				t.Fatalf("New() failed: %v", err)
 			}
 
-			_, err = client.CreateBucketSnapshot(context.Background(), tt.bucket, tt.description)
+			_, err = client.Snapshot(context.Background(), tt.bucket, tt.description)
 
 			if tt.wantErr && err == nil {
 				t.Errorf("CreateBucketSnapshot() expected error, got nil")
@@ -454,7 +454,7 @@ func TestBucketSnapshotList(t *testing.T) {
 	client = client.For(bucket)
 
 	snapshotName := t.Name()
-	sn, err := client.CreateBucketSnapshot(ctx, bucket, snapshotName)
+	sn, err := client.Snapshot(ctx, bucket, snapshotName)
 	if err != nil {
 		t.Fatalf("CreateBucketSnapshot(%q, %q) failed: %v", bucket, snapshotName, err)
 	}

--- a/simplestorage/buckets_test.go
+++ b/simplestorage/buckets_test.go
@@ -486,6 +486,7 @@ func collect[T any](i iter.Seq2[T, error]) ([]T, error) {
 	for item, err := range i {
 		if err != nil {
 			errs = append(errs, err)
+			continue
 		}
 
 		result = append(result, item)

--- a/simplestorage/buckets_test.go
+++ b/simplestorage/buckets_test.go
@@ -28,21 +28,19 @@ func setupTestBucket(t *testing.T, ctx context.Context, client *Client) string {
 	skipIfNoCreds(t)
 
 	bucket := fmt.Sprintf("test-bucket-%d", time.Now().UnixNano())
-	_, err := client.CreateBucket(ctx, bucket)
+	_, err := client.CreateBucket(ctx, bucket, WithEnableSnapshot())
 	if err != nil {
 		t.Fatalf("setupTestBucket: failed to create bucket %s: %v", bucket, err)
 	}
-	return bucket
-}
 
-// cleanupTestBucket deletes a bucket after testing.
-// Logs errors instead of failing, to avoid masking test failures.
-func cleanupTestBucket(t *testing.T, ctx context.Context, client *Client, bucket string) {
-	t.Helper()
-	err := client.DeleteBucket(ctx, bucket)
-	if err != nil {
-		t.Logf("cleanupTestBucket: failed to delete bucket %s: %v", bucket, err)
-	}
+	t.Cleanup(func() {
+		err := client.DeleteBucket(context.Background(), bucket)
+		if err != nil {
+			t.Logf("cleanupTestBucket: failed to delete bucket %s: %v", bucket, err)
+		}
+	})
+
+	return bucket
 }
 
 func TestCreateBucket(t *testing.T) {
@@ -75,12 +73,9 @@ func TestCreateBucket(t *testing.T) {
 			}
 			defer cleanup()
 
-			// Create a client (use a dummy bucket for object operations)
-			os.Setenv("TIGRIS_STORAGE_BUCKET", "dummy-bucket")
-			defer os.Unsetenv("TIGRIS_STORAGE_BUCKET")
-
 			client, err := New(context.Background(),
 				WithEndpoint("https://test.endpoint.dev"),
+				WithBucket("xxx-dummy-bucket"),
 			)
 			if err != nil {
 				t.Fatalf("New() failed: %v", err)
@@ -131,12 +126,9 @@ func TestDeleteBucket(t *testing.T) {
 			}
 			defer cleanup()
 
-			// Create a client
-			os.Setenv("TIGRIS_STORAGE_BUCKET", "dummy-bucket")
-			defer os.Unsetenv("TIGRIS_STORAGE_BUCKET")
-
 			client, err := New(context.Background(),
 				WithEndpoint("https://test.endpoint.dev"),
+				WithBucket("xxx-dummy-bucket"),
 			)
 			if err != nil {
 				t.Fatalf("New() failed: %v", err)
@@ -182,12 +174,9 @@ func TestListBuckets(t *testing.T) {
 			cleanup := tt.setupEnv
 			defer cleanup()
 
-			// Create a client
-			os.Setenv("TIGRIS_STORAGE_BUCKET", "dummy-bucket")
-			defer os.Unsetenv("TIGRIS_STORAGE_BUCKET")
-
 			client, err := New(context.Background(),
 				WithEndpoint("https://test.endpoint.dev"),
+				WithBucket("xxx-dummy-bucket"),
 			)
 			if err != nil {
 				t.Fatalf("New() failed: %v", err)
@@ -466,7 +455,6 @@ func TestBucketLifecycle_integration(t *testing.T) {
 
 	// Use setupTestBucket to verify the helper works
 	bucket := setupTestBucket(t, ctx, client)
-	defer cleanupTestBucket(t, ctx, client, bucket)
 
 	// Verify bucket was created
 	info, err := client.GetBucketInfo(ctx, bucket)

--- a/simplestorage/buckets_test.go
+++ b/simplestorage/buckets_test.go
@@ -232,7 +232,7 @@ func TestGetBucketInfo(t *testing.T) {
 				t.Fatalf("New() failed: %v", err)
 			}
 
-			_, err = client.GetBucketInfo(context.Background(), tt.bucket)
+			_, err = client.Info(context.Background(), tt.bucket)
 
 			if tt.wantErr && err == nil {
 				t.Errorf("GetBucketInfo() expected error, got nil")
@@ -432,7 +432,7 @@ func TestBucketLifecycle_integration(t *testing.T) {
 	bucket := setupTestBucket(t, ctx, client)
 
 	// Verify bucket was created
-	info, err := client.GetBucketInfo(ctx, bucket)
+	info, err := client.Info(ctx, bucket)
 	if err != nil {
 		t.Errorf("GetBucketInfo() failed: %v", err)
 	}

--- a/simplestorage/client.go
+++ b/simplestorage/client.go
@@ -59,43 +59,6 @@ func WithS3Options(opts ...func(*s3.Options)) ClientOption {
 	}
 }
 
-// WithStartAfter sets the StartAfter setting in List calls. Use this if you need
-// pagination in your List calls.
-func WithStartAfter(startAfter string) ClientOption {
-	return func(co *ClientOptions) {
-		co.StartAfter = aws.String(startAfter)
-	}
-}
-
-// WithMaxKeys sets the maximum number of keys in List calls. Use this along with
-// WithStartAfter for pagination in your List calls.
-func WithMaxKeys(maxKeys int32) ClientOption {
-	return func(co *ClientOptions) {
-		co.MaxKeys = &maxKeys
-	}
-}
-
-// WithDelimiter sets a delimiter for grouping keys in List calls.
-func WithDelimiter(delimiter string) ClientOption {
-	return func(co *ClientOptions) {
-		co.Delimiter = aws.String(delimiter)
-	}
-}
-
-// WithPrefix sets the prefix to filter keys in List calls.
-func WithPrefix(prefix string) ClientOption {
-	return func(co *ClientOptions) {
-		co.Prefix = aws.String(prefix)
-	}
-}
-
-// WithPaginationToken sets the pagination token to continue listing objects.
-func WithPaginationToken(token string) ClientOption {
-	return func(co *ClientOptions) {
-		co.PaginationToken = aws.String(token)
-	}
-}
-
 // WithContentType sets the Content-Type header. Used by Put (the object
 // Content-Type takes precedence when non-empty) and by presigned PUT URLs.
 func WithContentType(contentType string) ClientOption {
@@ -193,13 +156,6 @@ func WithAccessType(access AccessType) ClientOption {
 type ClientOptions struct {
 	BucketName string
 	S3Options  []func(*s3.Options)
-
-	// List options
-	StartAfter      *string
-	MaxKeys         *int32
-	Delimiter       *string
-	Prefix          *string
-	PaginationToken *string
 
 	// Put and presign options
 	ContentType        *string
@@ -500,28 +456,31 @@ func (c *Client) Delete(ctx context.Context, key string, opts ...ClientOption) e
 // List returns a list of objects matching the given criteria.
 //
 // This returns an iterator so you can loop over the values. The iterator handles
-// pagination for you.
-func (c *Client) List(ctx context.Context, opts ...ClientOption) iter.Seq2[*Object, error] {
-	o := new(ClientOptions).defaults(c.options)
-
+// pagination for you; the page size can be tuned with WithMaxKeys. Combine
+// WithPrefix and WithDelimiter to walk a single "directory" level, or
+// WithStartAfter and WithContinueToken to resume a previous listing.
+func (c *Client) List(ctx context.Context, opts ...ListOption) iter.Seq2[*Object, error] {
+	var lo listOptions
 	for _, doer := range opts {
-		doer(&o)
+		doer(&lo)
 	}
 
+	bucket := c.options.BucketName
+
 	return func(yield func(obj *Object, err error) bool) {
-		var continueToken *string
+		continueToken := lo.ContinueToken
 		for {
 			resp, err := c.cli.ListObjectsV2(
 				ctx,
 				&s3.ListObjectsV2Input{
-					Bucket:            new(o.BucketName),
-					Delimiter:         o.Delimiter,
-					Prefix:            o.Prefix,
-					MaxKeys:           o.MaxKeys,
+					Bucket:            new(bucket),
+					Delimiter:         lo.Delimiter,
+					Prefix:            lo.Prefix,
+					MaxKeys:           lo.MaxKeys,
 					ContinuationToken: continueToken,
-					StartAfter:        o.StartAfter,
+					StartAfter:        lo.StartAfter,
 				},
-				o.S3Options...,
+				lo.S3Options...,
 			)
 
 			if err != nil {
@@ -532,7 +491,7 @@ func (c *Client) List(ctx context.Context, opts ...ClientOption) iter.Seq2[*Obje
 			for _, obj := range resp.Contents {
 				if !yield(
 					&Object{
-						Bucket:       o.BucketName,
+						Bucket:       bucket,
 						Key:          lower(obj.Key, ""),
 						Etag:         lower(obj.ETag, ""),
 						Size:         lower(obj.Size, 0),
@@ -544,7 +503,7 @@ func (c *Client) List(ctx context.Context, opts ...ClientOption) iter.Seq2[*Obje
 				}
 			}
 
-			// If the response is not truncated, there are more results to be returned.
+			// If the response is not truncated, there are no more results to return.
 			if !*resp.IsTruncated {
 				return
 			}

--- a/simplestorage/client.go
+++ b/simplestorage/client.go
@@ -265,14 +265,6 @@ type Object struct {
 	Body               io.ReadCloser     // Body of the object so it can be read, don't forget to close it.
 }
 
-// ListResult contains the result of a List operation, including pagination information.
-type ListResult struct {
-	Items          []Object // List of objects
-	CommonPrefixes []string // Common prefixes grouped by delimiter (populated when WithDelimiter is set)
-	NextToken      string   // Pagination token for the next page
-	HasMore        bool     // Whether there are more objects to list
-}
-
 // Get fetches the contents of an object and its metadata from Tigris.
 func (c *Client) Get(ctx context.Context, key string, opts ...ClientOption) (*Object, error) {
 	o := new(ClientOptions).defaults(c.options)

--- a/simplestorage/client.go
+++ b/simplestorage/client.go
@@ -540,11 +540,11 @@ func (c *Client) List(ctx context.Context, opts ...ClientOption) iter.Seq2[*Obje
 				}
 			}
 
-			// An empty or absent continuation token means there are no more pages.
-			if resp.ContinuationToken == nil || *resp.ContinuationToken == "" {
+			// If the response is not truncated, there are more results to be returned.
+			if !*resp.IsTruncated {
 				return
 			}
-			continueToken = resp.ContinuationToken
+			continueToken = resp.NextContinuationToken
 		}
 	}
 }

--- a/simplestorage/client.go
+++ b/simplestorage/client.go
@@ -497,6 +497,10 @@ func (c *Client) Delete(ctx context.Context, key string, opts ...ClientOption) e
 	return nil
 }
 
+// List returns a list of objects matching the given criteria.
+//
+// This returns an iterator so you can loop over the values. The iterator handles
+// pagination for you.
 func (c *Client) List(ctx context.Context, opts ...ClientOption) iter.Seq2[*Object, error] {
 	o := new(ClientOptions).defaults(c.options)
 
@@ -547,64 +551,6 @@ func (c *Client) List(ctx context.Context, opts ...ClientOption) iter.Seq2[*Obje
 			continueToken = resp.NextContinuationToken
 		}
 	}
-}
-
-// List returns a list of objects matching the given criteria.
-//
-// The returned ListResult contains pagination information; use NextToken with
-// WithPaginationToken() to fetch the next page. HasMore indicates whether
-// additional objects are available. When WithDelimiter is set, CommonPrefixes
-// is populated with the grouped prefixes (for directory-like listings).
-func (c *Client) ListOld(ctx context.Context, opts ...ClientOption) (*ListResult, error) {
-	o := new(ClientOptions).defaults(c.options)
-
-	for _, doer := range opts {
-		doer(&o)
-	}
-
-	resp, err := c.cli.ListObjectsV2(
-		ctx,
-		&s3.ListObjectsV2Input{
-			Bucket:            aws.String(o.BucketName),
-			Delimiter:         o.Delimiter,
-			Prefix:            o.Prefix,
-			MaxKeys:           o.MaxKeys,
-			ContinuationToken: o.PaginationToken,
-			StartAfter:        o.StartAfter,
-		},
-		o.S3Options...,
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("simplestorage: can't list %s: %v", o.BucketName, err)
-	}
-
-	result := &ListResult{
-		Items:     make([]Object, 0, len(resp.Contents)),
-		NextToken: lower(resp.NextContinuationToken, ""),
-		HasMore:   lower(resp.IsTruncated, false),
-	}
-
-	for _, obj := range resp.Contents {
-		result.Items = append(result.Items, Object{
-			Bucket:       o.BucketName,
-			Key:          lower(obj.Key, ""),
-			Etag:         lower(obj.ETag, ""),
-			Size:         lower(obj.Size, 0),
-			LastModified: lower(obj.LastModified, time.Time{}),
-		})
-	}
-
-	if len(resp.CommonPrefixes) > 0 {
-		result.CommonPrefixes = make([]string, 0, len(resp.CommonPrefixes))
-		for _, p := range resp.CommonPrefixes {
-			if p.Prefix != nil {
-				result.CommonPrefixes = append(result.CommonPrefixes, *p.Prefix)
-			}
-		}
-	}
-
-	return result, nil
 }
 
 // PresignURL generates a presigned URL for the specified HTTP method, key, and expiry duration.

--- a/simplestorage/client.go
+++ b/simplestorage/client.go
@@ -504,7 +504,7 @@ func (c *Client) List(ctx context.Context, opts ...ListOption) iter.Seq2[*Object
 			}
 
 			// If the response is not truncated, there are no more results to return.
-			if !*resp.IsTruncated {
+			if !lower(resp.IsTruncated, false) {
 				return
 			}
 			continueToken = resp.NextContinuationToken

--- a/simplestorage/client.go
+++ b/simplestorage/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"net/http"
 	"time"
 
@@ -496,13 +497,65 @@ func (c *Client) Delete(ctx context.Context, key string, opts ...ClientOption) e
 	return nil
 }
 
+func (c *Client) List(ctx context.Context, opts ...ClientOption) iter.Seq2[*Object, error] {
+	o := new(ClientOptions).defaults(c.options)
+
+	for _, doer := range opts {
+		doer(&o)
+	}
+
+	return func(yield func(obj *Object, err error) bool) {
+		var continueToken *string
+		for {
+			resp, err := c.cli.ListObjectsV2(
+				ctx,
+				&s3.ListObjectsV2Input{
+					Bucket:            new(o.BucketName),
+					Delimiter:         o.Delimiter,
+					Prefix:            o.Prefix,
+					MaxKeys:           o.MaxKeys,
+					ContinuationToken: continueToken,
+					StartAfter:        o.StartAfter,
+				},
+				o.S3Options...,
+			)
+
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			for _, obj := range resp.Contents {
+				if !yield(
+					&Object{
+						Bucket:       o.BucketName,
+						Key:          lower(obj.Key, ""),
+						Etag:         lower(obj.ETag, ""),
+						Size:         lower(obj.Size, 0),
+						LastModified: lower(obj.LastModified, time.Time{}),
+					},
+					nil,
+				) {
+					return
+				}
+			}
+
+			// An empty or absent continuation token means there are no more pages.
+			if resp.ContinuationToken == nil || *resp.ContinuationToken == "" {
+				return
+			}
+			continueToken = resp.ContinuationToken
+		}
+	}
+}
+
 // List returns a list of objects matching the given criteria.
 //
 // The returned ListResult contains pagination information; use NextToken with
 // WithPaginationToken() to fetch the next page. HasMore indicates whether
 // additional objects are available. When WithDelimiter is set, CommonPrefixes
 // is populated with the grouped prefixes (for directory-like listings).
-func (c *Client) List(ctx context.Context, opts ...ClientOption) (*ListResult, error) {
+func (c *Client) ListOld(ctx context.Context, opts ...ClientOption) (*ListResult, error) {
 	o := new(ClientOptions).defaults(c.options)
 
 	for _, doer := range opts {

--- a/simplestorage/client_example_test.go
+++ b/simplestorage/client_example_test.go
@@ -186,19 +186,12 @@ func ExampleClient_List_delimiter() {
 	}
 
 	// Walk one "directory" level under prefix "reports/" using "/" as a delimiter.
-	result, err := client.List(ctx,
-		simplestorage.WithPrefix("reports/"),
-		simplestorage.WithDelimiter("/"),
-	)
-	if err != nil {
-		log.Fatal(err) // handle the error here
-	}
+	for obj, err := range client.List(ctx, simplestorage.WithPrefix("reports/"), simplestorage.WithDelimiter("/")) {
+		if err != nil {
+			log.Fatal(err) // handle error
+		}
 
-	for _, p := range result.CommonPrefixes {
-		fmt.Println("sub-prefix:", p)
-	}
-	for _, o := range result.Items {
-		fmt.Println("object:", o.Key)
+		fmt.Println("object:", obj)
 	}
 }
 

--- a/simplestorage/client_example_test.go
+++ b/simplestorage/client_example_test.go
@@ -191,7 +191,7 @@ func ExampleClient_List_delimiter() {
 			log.Fatal(err) // handle error
 		}
 
-		fmt.Println("object:", obj)
+		fmt.Println("object:", obj.Key)
 	}
 }
 

--- a/simplestorage/client_options_test.go
+++ b/simplestorage/client_options_test.go
@@ -46,15 +46,6 @@ func TestClientOptions(t *testing.T) {
 		verify func(*testing.T, *ClientOptions)
 	}{
 		{
-			name:   "WithDelimiter sets Delimiter",
-			option: WithDelimiter("/"),
-			verify: func(t *testing.T, o *ClientOptions) {
-				if o.Delimiter == nil || *o.Delimiter != "/" {
-					t.Errorf("Delimiter = %v, want %q", o.Delimiter, "/")
-				}
-			},
-		},
-		{
 			name:   "WithQuerySnapshotVersion sets SnapshotVersion",
 			option: WithQuerySnapshotVersion("test-version"),
 			verify: func(t *testing.T, o *ClientOptions) {
@@ -132,15 +123,6 @@ func TestClientOptions(t *testing.T) {
 			verify: func(t *testing.T, o *ClientOptions) {
 				if o.UploadProgressCallback == nil {
 					t.Errorf("UploadProgressCallback = nil, want non-nil")
-				}
-			},
-		},
-		{
-			name:   "WithPrefix sets Prefix",
-			option: WithPrefix("test-prefix/"),
-			verify: func(t *testing.T, o *ClientOptions) {
-				if o.Prefix == nil || *o.Prefix != "test-prefix/" {
-					t.Errorf("Prefix = %v, want %q", o.Prefix, "test-prefix/")
 				}
 			},
 		},

--- a/simplestorage/client_test.go
+++ b/simplestorage/client_test.go
@@ -3,7 +3,9 @@ package simplestorage
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
+	"strings"
 	"testing"
 
 	_ "github.com/joho/godotenv/autoload"
@@ -190,5 +192,48 @@ func TestClient_For(t *testing.T) {
 				t.Errorf("For() SecretAccessKey = %q, want %q", newClient.options.SecretAccessKey, original.options.SecretAccessKey)
 			}
 		})
+	}
+}
+
+func TestClientList(t *testing.T) {
+	skipIfNoCreds(t)
+	ctx := t.Context()
+
+	client, err := New(ctx, WithBucket("xxx-foo-test"))
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	bucket := setupTestBucket(t, ctx, client)
+	client = client.For(bucket)
+
+	key := t.Name()
+	body := "hello, world!\n"
+
+	if _, err := client.Put(ctx, &Object{
+		Key:  key,
+		Size: int64(len(body)),
+		Body: io.NopCloser(strings.NewReader(body)),
+	}); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	objs, err := collect(client.List(ctx))
+	if err != nil {
+		t.Fatalf("can't list objects in bucket: %v", err)
+	}
+
+	if len(objs) != 1 {
+		t.Errorf("wanted len(objs) == 1 but got: %d", len(objs))
+	}
+
+	gotObj := objs[0]
+
+	if gotObj.Key != key {
+		t.Errorf("wanted key %q, got: %q", key, gotObj.Key)
+	}
+
+	if gotObj.Size != int64(len(body)) {
+		t.Errorf("wanted size %d, got: %d", len(body), gotObj.Size)
 	}
 }

--- a/simplestorage/list_options.go
+++ b/simplestorage/list_options.go
@@ -1,0 +1,86 @@
+package simplestorage
+
+import "github.com/aws/aws-sdk-go-v2/service/s3"
+
+type listOptions struct {
+	// ContinueToken is the continuation token for this request
+	ContinueToken *string
+
+	// Delimiter sets the listing delimiter for this request.
+	Delimiter *string
+
+	// MaxKeys sets the maximum number of keys to return per loop iteration.
+	MaxKeys *int32
+
+	// Prefix sets the key prefix for this request.
+	Prefix *string
+
+	// StartAfter is where you want Tigris to start listing from in the bucket.
+	// This can be any key in the bucket.
+	StartAfter *string
+
+	// S3Options are middleware functions forwarded to the underlying
+	// ListObjectsV2 call. Use them for Tigris-specific headers such as
+	// tigrisheaders.WithSnapshotVersion.
+	S3Options []func(*s3.Options)
+}
+
+// ListOption configures a single List call. Pass any combination of these to
+// override the default listing behavior.
+type ListOption func(*listOptions)
+
+// WithContinueToken resumes a previous List call from the given continuation
+// token. Use the token returned by the prior page to fetch the next one.
+func WithContinueToken(token string) ListOption {
+	return func(li *listOptions) {
+		li.ContinueToken = new(token)
+	}
+}
+
+// WithDelimiter groups keys that share a common prefix up to the given
+// delimiter, collapsing them into a single result. The classic value is "/" to
+// emulate directory-style listings.
+func WithDelimiter(delimiter string) ListOption {
+	return func(li *listOptions) {
+		li.Delimiter = new(delimiter)
+	}
+}
+
+// WithMaxKeys caps the number of keys returned per underlying request. This
+// controls page size, not the total number of keys yielded by the iterator.
+func WithMaxKeys(maxKeys int32) ListOption {
+	return func(li *listOptions) {
+		li.MaxKeys = new(maxKeys)
+	}
+}
+
+// WithPrefix restricts the listing to keys that begin with the given prefix.
+func WithPrefix(prefix string) ListOption {
+	return func(li *listOptions) {
+		li.Prefix = new(prefix)
+	}
+}
+
+// WithStartAfter begins the listing immediately after the given key. The key
+// itself does not need to exist in the bucket; Tigris returns the next key in
+// lexicographic order.
+func WithStartAfter(key string) ListOption {
+	return func(li *listOptions) {
+		li.StartAfter = new(key)
+	}
+}
+
+// WithListS3Options appends middleware to the underlying ListObjectsV2 call.
+// Use this to apply Tigris-specific headers to a List call, for example reading
+// from a bucket snapshot:
+//
+//	for obj, err := range client.List(ctx,
+//		simplestorage.WithListS3Options(tigrisheaders.WithSnapshotVersion("v1")),
+//	) {
+//		// ...
+//	}
+func WithListS3Options(opts ...func(*s3.Options)) ListOption {
+	return func(li *listOptions) {
+		li.S3Options = append(li.S3Options, opts...)
+	}
+}

--- a/simplestorage/list_options_test.go
+++ b/simplestorage/list_options_test.go
@@ -1,0 +1,82 @@
+package simplestorage
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestListOptions(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		option ListOption
+		verify func(*testing.T, *listOptions)
+	}{
+		{
+			name:   "WithContinueToken sets ContinueToken",
+			option: WithContinueToken("next-page"),
+			verify: func(t *testing.T, lo *listOptions) {
+				if lo.ContinueToken == nil || *lo.ContinueToken != "next-page" {
+					t.Errorf("ContinueToken = %v, want %q", lo.ContinueToken, "next-page")
+				}
+			},
+		},
+		{
+			name:   "WithDelimiter sets Delimiter",
+			option: WithDelimiter("/"),
+			verify: func(t *testing.T, lo *listOptions) {
+				if lo.Delimiter == nil || *lo.Delimiter != "/" {
+					t.Errorf("Delimiter = %v, want %q", lo.Delimiter, "/")
+				}
+			},
+		},
+		{
+			name:   "WithMaxKeys sets MaxKeys",
+			option: WithMaxKeys(250),
+			verify: func(t *testing.T, lo *listOptions) {
+				if lo.MaxKeys == nil || *lo.MaxKeys != 250 {
+					t.Errorf("MaxKeys = %v, want 250", lo.MaxKeys)
+				}
+			},
+		},
+		{
+			name:   "WithPrefix sets Prefix",
+			option: WithPrefix("test-prefix/"),
+			verify: func(t *testing.T, lo *listOptions) {
+				if lo.Prefix == nil || *lo.Prefix != "test-prefix/" {
+					t.Errorf("Prefix = %v, want %q", lo.Prefix, "test-prefix/")
+				}
+			},
+		},
+		{
+			name:   "WithStartAfter sets StartAfter",
+			option: WithStartAfter("key-42"),
+			verify: func(t *testing.T, lo *listOptions) {
+				if lo.StartAfter == nil || *lo.StartAfter != "key-42" {
+					t.Errorf("StartAfter = %v, want %q", lo.StartAfter, "key-42")
+				}
+			},
+		},
+		{
+			name: "WithListS3Options appends to S3Options",
+			option: WithListS3Options(
+				func(*s3.Options) {},
+				func(*s3.Options) {},
+			),
+			verify: func(t *testing.T, lo *listOptions) {
+				if len(lo.S3Options) != 2 {
+					t.Errorf("len(S3Options) = %d, want 2", len(lo.S3Options))
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var lo listOptions
+			tt.option(&lo)
+			tt.verify(t, &lo)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This changes simplestorage to use the [iterator pattern](https://pkg.go.dev/iter) to transparently handle pagination when doing the following actions:

* Listing buckets
* Listing snapshots
* Listing objects in buckets

This is a **BREAKING CHANGE** as the old methods to return this data in an AWS-SDK shaped request response pair have been deleted. This library is still below version 1 so breaking changes are acceptable.

Additional functional testing has been added against Tigris with a unique forkable bucket per test run.

## Test plan

- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [x] Manual testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large breaking API surface for all consumers of list/get-bucket helpers; iterator and renamed methods require coordinated upgrades across dependents.
> 
> **Overview**
> **Breaking change:** `simplestorage` listing APIs no longer return paginated structs (`BucketList`, `SnapshotList`, `ListResult`). They now expose Go **`iter.Seq2`** iterators that walk all pages automatically.
> 
> Bucket APIs are renamed and reshaped: **`ListBuckets` → `Buckets`**, **`GetBucketInfo` → `Info`**, **`CreateBucketSnapshot` → `Snapshot`**, **`ListBucketSnapshots` → `Snapshots`**. Object listing **`List`** now yields `*Object` per step instead of a single `*ListResult`. List tuning moved to dedicated **`ListOption`** helpers in `list_options.go` (`WithPrefix`, `WithDelimiter`, `WithMaxKeys`, `WithContinueToken`, etc.) instead of `ClientOption`.
> 
> **New behavior:** optional **`WithGrabForkInfo()`** on `Buckets()` issues an extra metadata call per bucket for fork/snapshot fields. Snapshot iteration parses Tigris pseudo-bucket names into version and human-readable description. Low-level **`storage` client** reads Tigris headers from **`smithyhttp.Response`** (Smithy middleware). Module targets **Go 1.26**; examples and integration tests were updated for the iterator pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006496f83c23a8e2ffa605c072e44ec84b043392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->